### PR TITLE
Reactivity

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -28,7 +28,6 @@ pub fn build(b: *Build) void {
 
     const test_step = b.step("test", "Run unit tests");
     test_step.dependOn(&run_drasil_tests.step);
-    test_step.dependOn(check); // Ensure everything compiles
 }
 
 fn updateHtmlDataStep(b: *Build, target: Target, optimize: Optimize) void {

--- a/src/Manager.zig
+++ b/src/Manager.zig
@@ -71,14 +71,20 @@ pub const Event = enum(u32) {
 
     const Listener = struct {
         id: Id,
-        ctx: ?*anyopaque,
+        ctx: Context,
         cb: Fn,
 
         const Id = enum(u32) { _ };
     };
 
+    pub const Context = union(enum) {
+        none,
+        sti: SubTree.Index,
+        ptr: *anyopaque,
+    };
+
     pub const Fn = *const fn (
-        ctx: ?*anyopaque,
+        ctx: Context,
         manager: *Manager,
         data: ?*anyopaque,
     ) anyerror!void;
@@ -96,7 +102,7 @@ pub const Event = enum(u32) {
     pub fn addListener(
         event: Event,
         manager: *Manager,
-        ctx: ?*anyopaque,
+        ctx: Context,
         callback: Fn,
     ) !Listener.Id {
         const list = event.listeners(manager).?;

--- a/src/test.zig
+++ b/src/test.zig
@@ -257,13 +257,13 @@ test "callbacks" {
                     .event = event,
                 });
 
-                _ = try event.addListener(m, sti.contextPtr(m), callback);
+                _ = try event.addListener(m, .{ .sti = sti }, callback);
 
                 return sti;
             }
 
-            fn callback(ctx: ?*anyopaque, m: *Manager, _: ?*anyopaque) !void {
-                const case: *@This() = @alignCast(@ptrCast(ctx.?));
+            fn callback(ctx: Context, m: *Manager, _: ?*anyopaque) !void {
+                const case: *@This() = @alignCast(@ptrCast(ctx.sti.contextPtr(m)));
                 case.fired.getMut(m).* = true;
             }
 
@@ -316,7 +316,7 @@ test "nested callback" {
                 return sti;
             }
 
-            fn callback(_: ?*anyopaque, _: *Manager, _: ?*anyopaque) !void {}
+            fn callback(_: Context, _: *Manager, _: ?*anyopaque) !void {}
 
             fn generate(
                 sti: SubTree.Index,
@@ -359,7 +359,7 @@ test "nested callback" {
         _ = try nested.setContext(&manager, NestedCallback{ .event = event });
         try std.testing.expectEqual(0, @intFromEnum(nested));
 
-        _ = try event.addListener(&manager, null, NestedCallback.callback);
+        _ = try event.addListener(&manager, .none, NestedCallback.callback);
 
         const case = try manager.register(Case.generate);
         try case.setContext(&manager, Case{ .index = nested });
@@ -386,6 +386,7 @@ const assert = std.debug.assert;
 const Tree = drasil.Tree;
 const Manager = drasil.Manager;
 const Event = Manager.Event;
+const Context = Event.Context;
 const SubTree = Manager.SubTree;
 const Allocator = std.mem.Allocator;
 const Reactive = Manager.Reactive;


### PR DESCRIPTION
Add reactivity to the framework. This enables 'automatic' tracking of state dependencies between components, greatly simplifying some interactions.

Also: 
- Changes `Event.Fn`s context type to a union, to more easily pass `sti`. 
  - It might be an idea to make `Event` generic on the context type
- Remove the `check` step as a dependency for `test`, made debugging annoying