### PR TITLE
Fetch

### DIFF
--- a/example/counter/client.zig
+++ b/example/counter/client.zig
@@ -95,8 +95,6 @@ const AlternatingButton = struct {
         };
         const sti = ctx.sti.specific(@This());
 
-        std.log.info("Recieved data {x}", .{bytes});
-
         const value: u64 = std.mem.readInt(u64, bytes[0..@sizeOf(u64)], .little);
         std.log.info("Recieved prng seed {x}", .{value});
 

--- a/example/root_client.zig
+++ b/example/root_client.zig
@@ -128,7 +128,7 @@ const App = struct {
         \\cursor: pointer;
     ;
 
-    fn callback(ctx: Context, m: *Manager, data: ?*anyopaque) !void {
+    fn callback(ctx: Context, m: *Manager, data: Data) !void {
         _ = data;
         _ = m;
 
@@ -179,5 +179,6 @@ const SubTree = Manager.SubTree;
 const Tree = drasil.Tree;
 const Event = Manager.Event;
 const Context = Event.Context;
+const Data = Event.Data;
 const Allocator = std.mem.Allocator;
 const Element = web.Element;

--- a/example/root_client.zig
+++ b/example/root_client.zig
@@ -33,6 +33,7 @@ var state: State = undefined;
 pub fn setup() !void {
     // FIXME: I really dislike this style of initialization. Perhaps let the manager live in web.
     state.manager = .init(global.gpa);
+    web.setup(&state.manager, global.gpa);
 
     state.browser_app = try App.init(&state.manager);
     state.counter_app = try counter.App.init(&state.manager);
@@ -40,7 +41,6 @@ pub fn setup() !void {
 
     state.screen = .none;
 
-    web.setup(&state.manager, global.gpa);
     std.log.info("After web setup", .{});
 
     try setupStatic();

--- a/example/table/client.zig
+++ b/example/table/client.zig
@@ -72,8 +72,6 @@ pub const App = struct {
 
         const sti = ctx.sti.specific(@This());
 
-        std.log.info("Recieved data {x}", .{bytes});
-
         const value: u64 = std.mem.readInt(u64, bytes[0..@sizeOf(u64)], .little);
         std.log.info("Recieved prng seed {x}", .{value});
 

--- a/src/Manager.zig
+++ b/src/Manager.zig
@@ -202,6 +202,14 @@ pub const SubTree = struct {
         pub fn listen(index: GenericIndex, m: *Manager, event: Event) !Event.Listener.Id {
             return try event.addListener(m, .{ .sti = index }, dirtyCallback);
         }
+
+        pub fn updateGenerator(self: GenericIndex, m: *Manager, generator: Generator) void {
+            std.log.info("Updating generator", .{});
+
+            const t = self.tree(m);
+            t.generator = generator;
+            t.dirty();
+        }
     };
 
     pub fn Index(comptime T: type) type {
@@ -241,6 +249,10 @@ pub const SubTree = struct {
 
             pub fn listen(self: Self, m: *Manager, event: Event) !Event.Listener.Id {
                 return try self.generic().listen(m, event);
+            }
+
+            pub fn updateGenerator(self: Self, m: *Manager, generator: Self.Generator) void {
+                self.generic().updateGenerator(m, @ptrCast(generator));
             }
         };
     }

--- a/src/test.zig
+++ b/src/test.zig
@@ -262,7 +262,7 @@ test "callbacks" {
                 return sti;
             }
 
-            fn callback(ctx: Context, m: *Manager, _: ?*anyopaque) !void {
+            fn callback(ctx: Context, m: *Manager, _: Data) !void {
                 const case = ctx.sti.specific(@This()).context(m).?;
                 (try case.fired.getMut(m, ctx.sti)).* = true;
             }
@@ -294,7 +294,7 @@ test "callbacks" {
             defer alloc.free(render);
             try std.testing.expectEqualStrings("false", render);
         }
-        try event.fire(&manager, null);
+        try event.fire(&manager, .none);
         {
             const render = try case.render(&manager);
             defer alloc.free(render);
@@ -316,7 +316,7 @@ test "nested callback" {
                 return sti;
             }
 
-            fn callback(_: Context, _: *Manager, _: ?*anyopaque) !void {}
+            fn callback(_: Context, _: *Manager, _: Data) !void {}
 
             fn generate(
                 sti: SubTree.Index(@This()),
@@ -387,6 +387,7 @@ const Tree = drasil.Tree;
 const Manager = drasil.Manager;
 const Event = Manager.Event;
 const Context = Event.Context;
+const Data = Event.Data;
 const SubTree = Manager.SubTree;
 const Allocator = std.mem.Allocator;
 const Reactive = Manager.Reactive;

--- a/src/test.zig
+++ b/src/test.zig
@@ -264,7 +264,7 @@ test "callbacks" {
 
             fn callback(ctx: Context, m: *Manager, _: ?*anyopaque) !void {
                 const case = ctx.sti.specific(@This()).context(m).?;
-                case.fired.getMut(m).* = true;
+                (try case.fired.getMut(m, ctx.sti)).* = true;
             }
 
             fn generate(

--- a/src/web.zig
+++ b/src/web.zig
@@ -20,6 +20,10 @@ export fn init() void {
     root.setup() catch |err|
         std.debug.panic("Init error: {s}", .{@errorName(err)});
 
+    render();
+}
+
+fn render() void {
     root.render() catch |err|
         std.debug.panic("Render error: {s}", .{@errorName(err)});
 }
@@ -43,8 +47,7 @@ export fn handleEvent(
         std.debug.panic("Firing event error: {s}", .{@errorName(err)});
 
     // TODO: see if we can avoid rerenders in callbacks
-    root.render() catch |err|
-        std.debug.panic("Render error: {s}", .{@errorName(err)});
+    render();
 }
 
 pub const js = struct {
@@ -190,6 +193,9 @@ pub const js = struct {
 
                 req.callback(req.ctx, data.to()) catch |err|
                     std.debug.panic("Fetch handle failed: {s}", .{@errorName(err)});
+
+                // The fetch might require some components to rerender
+                render();
 
                 return;
             }

--- a/src/web/init.js
+++ b/src/web/init.js
@@ -196,11 +196,7 @@ async function init(wasm_target) {
 
         fetch(target)
           .then((res) => res.bytes())
-          .then((bytes) => {
-            console.log("JS: Got fetch result");
-
-            wasm_exports.handleFetch(id, storeBytes(bytes));
-          })
+          .then((bytes) => wasm_exports.handleFetch(id, storeBytes(bytes)))
           .catch((reason) => {
             console.error(`Error while fetching ${reason}`);
             wasm_exports.handleFetch(id, 0n);


### PR DESCRIPTION
Teach drasil to fetch data using the browsers `fetch` api. This is done by craating an event and callback. 

In the end everything is an event.

Additionally:
- `Event.Fn` data now is a type close to `Event.Context`
- `SubTree.Index` can update it's generator
  - This allows the usecases of showing a temporary screen while waiting for data to load. This is basically required as we cannot await an async operation like fetch. We need to defer back to JS before that can happen. 
- `Reactive` has a new `set` function, which does what you would expect
- Makes the examples fetch a seed from the server